### PR TITLE
Add committers avatar to commit tree items

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 <p align="center"><a href="https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github"><img src="https://vsmarketplacebadge.apphb.com/version/GitHub.vscode-pull-request-github.svg?label=GitHub%20Pull%20Requests&colorB=196EC5" alt="Marketplace bagde"></a> <a href="https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github#review-details"><img src="https://img.shields.io/vscode-marketplace/r/GitHub.vscode-pull-request-github.svg?label=Ratings&colorB=063063" alt="Marketplace Rating"></a></p>
 
 This extension allows you to review and manage GitHub pull requests in Visual Studio Code. The support includes:
-- Authenticate and connect VS Code to GitHub
-- List and browse PRs from within VS Code
-- Review PRs from within VS Code with in-editor commenting.
+- Authenticating and connecting VS Code to GitHub.
+- Listing and browsing PRs from within VS Code.
+- Reviewing PRs from within VS Code with in-editor commenting.
 - Validating PRs from within VS Code with easy checkouts.
 - Terminal integration that enables UI and CLIs to co-exist.
 
@@ -21,12 +21,12 @@ This extension allows you to review and manage GitHub pull requests in Visual St
 # How to get started?
 It's easy to get started with GitHub Pull Requests for Visual Studio Code. Simply follow these steps to get started.
 
-1. Make sure you have VSCode version 1.27.0 or higher
-1. Download the extension from [the marketplace](https://aka.ms/vscodepr-download)
-1. Reload VS Code after the installation (click the reload button next to the extension)
-1. Open your desired GitHub repo
+1. Make sure you have VSCode version 1.27.0 or higher.
+1. Download the extension from [the marketplace](https://aka.ms/vscodepr-download).
+1. Reload VS Code after the installation (click the reload button next to the extension).
+1. Open your desired GitHub repository.
 1. Go to the SCM Viewlet, and you should see the `GitHub Pull Requests` treeview. On the first load, it will appear collapsed at the bottom of the viewlet.
-1. A notification should appear asking you to sign in to GitHub; follow the directions to authenticate
+1. A notification should appear asking you to sign in to GitHub; follow the directions to authenticate.
 1. You should be good to go!
 
 # Extension

--- a/src/view/treeNodes/commitNode.ts
+++ b/src/view/treeNodes/commitNode.ts
@@ -14,6 +14,7 @@ import { Comment } from '../../common/comment';
 
 export class CommitNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
+	public iconPath: vscode.Uri;
 	public collapsibleState: vscode.TreeItemCollapsibleState;
 
 	constructor(
@@ -25,6 +26,9 @@ export class CommitNode extends TreeNode implements vscode.TreeItem {
 		super();
 		this.label = commit.commit.message;
 		this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+		this.iconPath = commit.author && commit.author.avatar_url
+			? vscode.Uri.parse(`${commit.author.avatar_url}&s=64`)
+			: undefined;
 	}
 
 	getTreeItem(): vscode.TreeItem {


### PR DESCRIPTION
Adds the committer's avatar to the tree:
			![screen shot 2018-10-04 at 10 48 25 am](https://user-images.githubusercontent.com/3672607/46494442-c312ab00-c7c7-11e8-9edf-037990323e7d.png)
			