### PR TITLE
Add committers avatar to commit tree items

### DIFF
--- a/src/view/treeNodes/commitNode.ts
+++ b/src/view/treeNodes/commitNode.ts
@@ -14,6 +14,7 @@ import { Comment } from '../../common/comment';
 
 export class CommitNode extends TreeNode implements vscode.TreeItem {
 	public label: string;
+	public iconPath: vscode.Uri;
 	public collapsibleState: vscode.TreeItemCollapsibleState;
 
 	constructor(
@@ -25,6 +26,9 @@ export class CommitNode extends TreeNode implements vscode.TreeItem {
 		super();
 		this.label = commit.commit.message;
 		this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+		this.iconPath = commit.author && commit.author.avatar_url
+			? vscode.Uri.parse(`${commit.author.avatar_url}&s=64`)
+			: undefined;
 	}
 
 	getTreeItem(): vscode.TreeItem {


### PR DESCRIPTION
Adds the committer's avatar to the tree:

![screen shot 2018-10-04 at 10 48 25 am](https://user-images.githubusercontent.com/3672607/46494442-c312ab00-c7c7-11e8-9edf-037990323e7d.png)
			